### PR TITLE
two small insertions + signaling one error

### DIFF
--- a/src/OSmOSE/utils.py
+++ b/src/OSmOSE/utils.py
@@ -64,12 +64,12 @@ def list_not_built_datasets(datasets_folder_path: str) -> None:
             list_unknown_datasets.append(dataset_directory)
 
     not_built_formatted = "\n".join(
-        [f"  - {os.path.basename(dataset)}" for dataset in list_not_built_datasets]
+        [f"  - {dataset.name}" for dataset in list_not_built_datasets]
     )
     print(f"""List of the datasets that aren't built yet:\n{not_built_formatted}""")
 
     unreachable_formatted = "\n".join(
-        [f"  - {os.path.basename(dataset)}" for dataset in list_unknown_datasets]
+        [f"  - {dataset.name}" for dataset in list_unknown_datasets]
     )
     print(
         f"""List of unreachable datasets (probably due to insufficient permissions:\n{unreachable_formatted}"""


### PR DESCRIPTION
two "cosmetic" insertions for text display

be careful to this error :
when you hit the error related to date_template , it still sets the audio path : '/home/datawork-osmose/dataset/test_rumengol/data/audio/original/' , when user will reexecute build dataset , it runs into a new error in the function _find_original_folder that does not find the original just created (goes into the second elif # If there is exactly one folder in the dataset folder)..