### PR TITLE
Update core_utils.py

### DIFF
--- a/src/OSmOSE/utils/core_utils.py
+++ b/src/OSmOSE/utils/core_utils.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 import sys
 from typing import Union, NamedTuple, Tuple, List
 import pytz
+import glob
 
 import pandas as pd
 


### PR DESCRIPTION
added import glob as the module was missing and generates an error when one tries to use list_aplose function