### PR TITLE
add custom freq to spectrogram foldername

### DIFF
--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -455,9 +455,7 @@ class Spectrogram(Dataset):
         audio_foldername = f"{str(self.spectro_duration)}_{str(self.dataset_sr)}"
         self.audio_path = self.path.joinpath(OSMOSE_PATH.raw_audio, audio_foldername)
 
-        self.__spectro_foldername = (
-            f"{str(self.nfft)}_{str(self.window_size)}_{str(self.overlap)}"
-        )
+        self.__spectro_foldername = f"{str(self.nfft)}_{str(self.window_size)}_{str(self.overlap)}_{self.custom_frequency_scale}"
 
         self.path_output_spectrogram = processed_path.joinpath(
             audio_foldername, self.__spectro_foldername, "image"
@@ -939,7 +937,7 @@ class Spectrogram(Dataset):
             meta_path = self.path.joinpath(
                 OSMOSE_PATH.spectrogram,
                 f"{str(self.spectro_duration)}_{str(self.dataset_sr)}",
-                f"{str(self.nfft)}_{str(self.window_size)}_{str(self.overlap)}",
+                f"{str(self.nfft)}_{str(self.window_size)}_{str(self.overlap)}_{self.custom_frequency_scale}",
                 "metadata.csv",
             )
 


### PR DESCRIPTION
This PR contains the foldername modif that I am currently using in FEM servers.
I think you guys removed it at the moment because incompatible with your local systems ?
**Can someone tell me why we decided to NOT write in foldername ?**

I write the code in this PR in case you want to do it after all, and to recall that I made this modif at FEM.

DO NOT MERGE THIS, UNITTESTS NOT ADAPTED RIGHT NOW.