### PR TITLE
Lazy normalization values

### DIFF
--- a/src/osekit/core_api/audio_data.py
+++ b/src/osekit/core_api/audio_data.py
@@ -117,7 +117,9 @@ class AudioData(BaseData[AudioItem, AudioFile]):
                 "peak": self.get_peak(raw_values=values),
                 "std": values.std(),
             }
-        total_length = np.sum(part.shape[0] for part in parts)
+        total_length = np.sum(
+            part.shape if type(part.shape) is int else part.shape[0] for part in parts
+        )
         mean = np.sum(
             [part.get_mean(total_length=total_length) for part in parts],
             dtype=np.float64,

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1559,7 +1559,7 @@ def test_split_data(
             range(0, data.shape, subdata_shape),
             strict=False,
         ):
-            assert np.array_equal(
+            assert np.allclose(
                 subdata.get_value(),
                 data.get_value()[data_range : data_range + subdata_shape],
             )
@@ -1919,8 +1919,8 @@ def test_normalization_values(
         self.normalization_values = kwargs.pop("normalization_values", None)
         self.mocked_values = kwargs.pop("mocked_values", None)
 
-    def mocked_shape(self: AudioData) -> tuple[int, int]:
-        return len(self.mocked_values), 1
+    def mocked_shape(self: AudioData) -> int:
+        return len(self.mocked_values)
 
     monkeypatch.setattr(AudioData, "__init__", mocked_init)
     monkeypatch.setattr(AudioData, "shape", property(mocked_shape))


### PR DESCRIPTION
# 🐳 What's up?

The changes in #280 imply computing the mean, std and peak values of an audio data before splitting it, to pass the normalization parameters.

In the case of a very large LTAS, it led to trying to allocate hundreds of GB into RAM, which obviously wasn't a good idea.

In this PR, the mean, std and peak are computed on each split data independently: that might not be sufficient (in case of a LTAS representing weaks with e.g. 5000 bins, 1/5000 of the duration might still be too long) so we'll have to try that out on actual data.

I'll try to think of a different approach if that is the case (plus I feel the current implementation is a bit dirty so I migth tweak it a bit before merging it anyways)