### PR TITLE
[DRAFT] Zoom levels in Analysis

### DIFF
--- a/docs/source/example_multiple_spectrograms_id_public.ipynb
+++ b/docs/source/example_multiple_spectrograms_id_public.ipynb
@@ -175,7 +175,7 @@
    "source": [
     "from pandas import Timedelta\n",
     "\n",
-    "spectro_dataset = dataset.get_analysis_spectrodataset(analysis)\n",
+    "spectro_dataset = dataset.get_analysis_spectrodatasets(analysis)\n",
     "\n",
     "for sd in spectro_dataset.data:\n",
     "    sd.name = next(iter(sd.audio_data.files)).path.stem\n",

--- a/docs/source/example_multiple_spectrograms_public.ipynb
+++ b/docs/source/example_multiple_spectrograms_public.ipynb
@@ -243,7 +243,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "analysis_spectro_dataset = dataset.get_analysis_spectrodataset(\n",
+    "analysis_spectro_dataset = dataset.get_analysis_spectrodatasets(\n",
     "    analysis=analysis,\n",
     "    audio_dataset=audio_dataset,  # So that the filtered SpectroDataset is returned\n",
     ")\n",

--- a/src/osekit/public_api/analysis.py
+++ b/src/osekit/public_api/analysis.py
@@ -81,7 +81,7 @@ class Analysis:
         scale: Scale | None = None,
         nb_ltas_time_bins: int | None = None,
         zoom_levels: list[int] | None = None,
-        zoomed_fft: list[ShortTimeFFT] | None = None,
+        zoomed_ffts: list[ShortTimeFFT] | None = None,
     ) -> None:
         """Initialize an Analysis object.
 
@@ -153,7 +153,7 @@ class Analysis:
             This will only affect spectral exports, and if AnalysisType.AUDIO is
             included in the analysis, zoomed SpectroDatasets will be linked to the
             x1 zoom SpectroData.
-        zoomed_fft: list[ShortTimeFFT | None]
+        zoomed_ffts: list[ShortTimeFFT | None]
             FFT to use for computing the zoomed spectra.
             By default, SpectroDatasets with a zoomed factor z will use the
             same FFT as the z=1 SpectroDataset, but with a hop that is
@@ -182,8 +182,8 @@ class Analysis:
         self.fft = fft
         self.zoom_levels = list({1, *zoom_levels}) if zoom_levels else None
         self.zoomed_fft = (
-            zoomed_fft
-            if zoomed_fft
+            zoomed_ffts
+            if zoomed_ffts
             else self._get_zoomed_ffts(x1_fft=fft, zoom_levels=self.zoom_levels)
         )
 

--- a/src/osekit/public_api/analysis.py
+++ b/src/osekit/public_api/analysis.py
@@ -81,7 +81,7 @@ class Analysis:
         scale: Scale | None = None,
         nb_ltas_time_bins: int | None = None,
         zoom_levels: list[int] | None = None,
-        zoomed_ffts: list[ShortTimeFFT] | None = None,
+        zoom_ffts: list[ShortTimeFFT] | None = None,
     ) -> None:
         """Initialize an Analysis object.
 
@@ -153,7 +153,7 @@ class Analysis:
             This will only affect spectral exports, and if AnalysisType.AUDIO is
             included in the analysis, zoomed SpectroDatasets will be linked to the
             x1 zoom SpectroData.
-        zoomed_ffts: list[ShortTimeFFT | None]
+        zoom_ffts: list[ShortTimeFFT | None]
             FFT to use for computing the zoomed spectra.
             By default, SpectroDatasets with a zoomed factor z will use the
             same FFT as the z=1 SpectroDataset, but with a hop that is
@@ -181,11 +181,7 @@ class Analysis:
 
         self.fft = fft
         self.zoom_levels = list({1, *zoom_levels}) if zoom_levels else None
-        self.zoomed_fft = (
-            zoomed_ffts
-            if zoomed_ffts
-            else self._get_zoomed_ffts(x1_fft=fft, zoom_levels=self.zoom_levels)
-        )
+        self.zoom_ffts = zoom_ffts
 
     @property
     def is_spectro(self) -> bool:
@@ -198,42 +194,3 @@ class Analysis:
                 AnalysisType.WELCH,
             )
         )
-
-    @staticmethod
-    def _get_zoomed_ffts(
-        x1_fft: ShortTimeFFT,
-        zoom_levels: list[int] | None,
-    ) -> list[ShortTimeFFT]:
-        """Compute the default FFTs to use for computing the zoomed spectra.
-
-        By default, SpectroDatasets with a zoomed factor z will use the
-        same FFT as the z=1 SpectroDataset, but with a hop that is
-        divided by z.
-
-        Parameters
-        ----------
-        x1_fft: ShortTimeFFT
-            FFT used for computing the unzoomed spectra.
-        zoom_levels: list[int] | None
-            Additional zoom levels used for computing the spectra.
-
-        Returns
-        -------
-        list[ShortTimeFFT]
-        FFTs used for computing the zoomed spectra.
-
-        """
-        if not zoom_levels:
-            return []
-        zoomed_ffts = []
-        for zoom_level in zoom_levels:
-            if zoom_level == 1:
-                continue
-            zoomed_ffts.append(
-                ShortTimeFFT(
-                    win=x1_fft.win,
-                    hop=x1_fft.hop // zoom_level,
-                    fs=x1_fft.fs,
-                ),
-            )
-        return zoomed_ffts

--- a/src/osekit/public_api/dataset.py
+++ b/src/osekit/public_api/dataset.py
@@ -749,7 +749,7 @@ class Dataset:
             "analysis": dataset["analysis"],
             "json": str(dataset["dataset"].folder / f"{name}.json"),
         }
-        if type(dataset) in (SpectroDataset, LTASDataset):
+        if type(dataset["dataset"]) in (SpectroDataset, LTASDataset):
             output |= {
                 "zoom_level": dataset["zoom_level"],
                 "zoom_reference": dataset["zoom_reference"],

--- a/src/osekit/public_api/dataset.py
+++ b/src/osekit/public_api/dataset.py
@@ -787,6 +787,9 @@ class Dataset:
                 "analysis": dataset["analysis"],
                 "dataset": dataset_class.from_json(Path(dataset["json"])),
             }
+            for zoom_info in ("zoom_level", "zoom_reference"):
+                if zoom_info in dataset:
+                    datasets[name][zoom_info] = dataset[zoom_info]
         return cls(
             folder=Path(),
             instrument=Instrument.from_dict(dictionary["instrument"]),

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1036,7 +1036,7 @@ def test_get_analysis_spectrodataset(
     )
     dataset.build()
 
-    analysis_sds = dataset.get_analysis_spectrodataset(analysis=analysis)
+    analysis_sds, _ = dataset.get_analysis_spectrodatasets(analysis=analysis)
 
     assert all(
         ad.begin == e.begin and ad.end == e.end
@@ -1411,61 +1411,3 @@ def test_spectro_analysis_with_existing_ads(
         assert ad.begin == sd.begin
         assert ad.end == sd.end
         assert sd.audio_data == ad
-
-
-@pytest.mark.parametrize(
-    ("fft", "zoomed_levels", "expected"),
-    [
-        pytest.param(
-            ShortTimeFFT(hamming(1024), hop=1024, fs=24_000),
-            None,
-            [],
-            id="no_zoom",
-        ),
-        pytest.param(
-            ShortTimeFFT(hamming(1024), hop=1024, fs=24_000),
-            [1],
-            [],
-            id="x1_zoom_only_equals_no_zoom",
-        ),
-        pytest.param(
-            ShortTimeFFT(hamming(1024), hop=1024, fs=24_000),
-            [2],
-            [
-                ShortTimeFFT(hamming(1024), hop=512, fs=24_000),
-            ],
-            id="x2_zoom_only",
-        ),
-        pytest.param(
-            ShortTimeFFT(hamming(1024), hop=1024, fs=24_000),
-            [2, 4, 8],
-            [
-                ShortTimeFFT(hamming(1024), hop=512, fs=24_000),
-                ShortTimeFFT(hamming(1024), hop=256, fs=24_000),
-                ShortTimeFFT(hamming(1024), hop=128, fs=24_000),
-            ],
-            id="multiple_zoom_levels",
-        ),
-        pytest.param(
-            ShortTimeFFT(hamming(1024), hop=1024, fs=24_000),
-            [3],
-            [
-                ShortTimeFFT(hamming(1024), hop=341, fs=24_000),
-            ],
-            id="hop_is_rounded_down",
-        ),
-    ],
-)
-def test_default_zoomed_sft(
-    fft: ShortTimeFFT,
-    zoomed_levels: list[int] | None,
-    expected: list[ShortTimeFFT],
-) -> None:
-    for sft, expected_sft in zip(
-        Analysis._get_zoomed_ffts(fft, zoomed_levels),
-        expected,
-        strict=True,
-    ):
-        assert np.array_equal(sft.win, expected_sft.win)
-        assert sft.hop == expected_sft.hop
-        assert sft.fs == expected_sft.fs


### PR DESCRIPTION
# 🐳 Z🔎🔍M

This PR brings back the ability to export zoomed spectrograms to APLOSE.

It itends at being a bit more configurable than before:

## 🐬 User POV

From the user perspective, it would look like that:

```py
analysis = Analysis(
    ...
    zoom_levels=[2,3,8], # List of desired zoom levels, which are no more necessarily powers of 2
    zoomed_ffts=None, # There are values by default but one could explicit the FFT used for each zoom level
)

dataset.run_analysis(analysis) # That's it
```

The default `zoomed_ffts` values would be, for a given zoom level `z`, a `ShortTimeFFT` instance that is the same as the given sft for the unzoomed specification (the one given as the `fft` parameter to the analysis), with its hop divided by z:
```py
default_zoomed_sft = ShortTimeFFT(
   win=sft.win,
   hop=sft.hop // zoom_level,
   fs=sft.fs,
)
```

## 🐬 Exported data

Then, running the analysis with the specified zoom levels would export **one SpectroDataset per zoom level**, with the link between zoom analyses being specified in the `dataset.json` file:

```json
{
    "datasets": {
        "original": {
            "analysis": "original",
            "class": "AudioDataset",
            "json": "data\\audio\\original\\original.json"
        },
        "cool_analysis_audio": {
            "analysis": "cool_analysis",
            "class": "AudioDataset",
            "json": "data\\audio\\cool_analysis_audio\\cool_analysis_audio.json"
        },
        "cool_analysis": {
            "analysis": "cool_analysis",
            "class": "SpectroDataset",
            "json": "processed\\cool_analysis\\cool_analysis.json",
            "zoom_level": 1,
            "zoom_reference": null
        },
        "cool_analysis_x2": {
            "analysis": "cool_analysis",
            "class": "SpectroDataset",
            "json": "processed\\cool_analysis_x2\\cool_analysis_x2.json",
            "zoom_level": 2,
            "zoom_reference": "cool_analysis"
        }
    },
    "depth": 0.0,
    "gps_coordinates": [
        0,
        0
    ],
    "instrument": null,
    "strptime_format": null,
    "timezone": null
}
```

Then, I'd add to the public API Dataset some methods to recover all zoomed datasets from the unzoomed version etc.

## 🐬 Note on AudioDatasets

As of now, I'm not sure there is a scenario in which exporting each "zoomed" audio split has any interest.

I think I'll just apply the zoom parameters to the **spectral** analysis, and in a scenario where the analysis includes `AnalysisType.AUDIO` (audio export), I'll only export the **unzoomed AudioDataset** and link all **zoomed SpectroDatasets** to this exported audio.