### PR TITLE
fix resampler flush dimensions

### DIFF
--- a/src/osekit/core_api/audio_data.py
+++ b/src/osekit/core_api/audio_data.py
@@ -228,9 +228,9 @@ class AudioData(BaseData[AudioItem, AudioFile]):
     ) -> np.ndarray:
         flush = resampler.resample_chunk(np.array([]), last=True)
         if len(flush) == 0:
-            return np.array([])
+            return np.array([])[:, None]
         if not remaining_samples:
-            return np.array([])
+            return np.array([])[:, None]
         flush = flush[:remaining_samples]
         return flush[:, None] if flush.ndim == 1 else flush
 


### PR DESCRIPTION
# 🐳 A bug, again??

Yeah, but a small one: When I flushed the resampler and the latter was empty, I returned an 1D empty array. 
However, I forced every audio array in OSEkit to be 2D to avoid issues with mono/multichannel audio, so I ended up having an error when streaming an audio data that ended with silence.