### PR TITLE
Read dataset metadata

### DIFF
--- a/src/osekit/core_api/audio_data.py
+++ b/src/osekit/core_api/audio_data.py
@@ -228,9 +228,9 @@ class AudioData(BaseData[AudioItem, AudioFile]):
     ) -> np.ndarray:
         flush = resampler.resample_chunk(np.array([]), last=True)
         if len(flush) == 0:
-            return np.array([])
+            return np.array([])[:, None]
         if not remaining_samples:
-            return np.array([])
+            return np.array([])[:, None]
         flush = flush[:remaining_samples]
         return flush[:, None] if flush.ndim == 1 else flush
 

--- a/src/osekit/public_api/dataset.py
+++ b/src/osekit/public_api/dataset.py
@@ -121,7 +121,7 @@ class Dataset:
     @property
     def origin_dataset(self) -> AudioDataset:
         """Return the ``AudioDataset`` from which this ``Dataset`` has been built."""
-        return self.get_dataset("original")
+        return self.deserialize_analysis_dataset("original")
 
     @property
     def analyses(self) -> list[str]:
@@ -660,9 +660,9 @@ class Dataset:
 
         """
         return [
-            dataset["dataset"]
-            for dataset in self.datasets.values()
-            if dataset["analysis"] == analysis_name
+            self.deserialize_analysis_dataset(analyis_dataset_name=dataset_name)
+            for dataset_name, dataset_values in self.datasets.items()
+            if dataset_values["analysis"] == analysis_name
         ]
 
     def rename_analysis(self, analysis_name: str, new_analysis_name: str) -> None:
@@ -742,7 +742,7 @@ class Dataset:
         if dataset_name not in self.datasets:
             message = f"Dataset '{dataset_name}' not found."
             raise ValueError(message)
-        return self.datasets[dataset_name]["dataset"]
+        return self.deserialize_analysis_dataset(analyis_dataset_name=dataset_name)
 
     def to_dict(self) -> dict:
         """Serialize a dataset to a dictionary.
@@ -758,7 +758,9 @@ class Dataset:
                 name: {
                     "class": dataset["class"],
                     "analysis": dataset["analysis"],
-                    "json": str(dataset["dataset"].folder / f"{name}.json"),
+                    "json": str(dataset["dataset"])
+                    if isinstance(dataset["dataset"], Path)
+                    else str(dataset["dataset"].folder / f"{name}.json"),
                 }
                 for name, dataset in self.datasets.items()
             },
@@ -788,16 +790,10 @@ class Dataset:
         """
         datasets = {}
         for name, dataset in dictionary["datasets"].items():
-            dataset_class = {
-                "AudioDataset": AudioDataset,
-                "SpectroDataset": SpectroDataset,
-                "LTASDataset": LTASDataset,
-            }[dataset["class"]]
-
             datasets[name] = {
                 "class": dataset["class"],
                 "analysis": dataset["analysis"],
-                "dataset": dataset_class.from_json(Path(dataset["json"])),
+                "dataset": Path(dataset["json"]),
             }
         return cls(
             folder=Path(),
@@ -833,6 +829,23 @@ class Dataset:
         instance.folder = file.parent
         instance._create_logger()  # noqa: SLF001
         return instance
+
+    def deserialize_analysis_dataset(
+        self,
+        analyis_dataset_name: str,
+    ) -> type[DatasetChild]:
+        analysis_dataset = self.datasets[analyis_dataset_name]
+        dataset_classes = {
+            "AudioDataset": AudioDataset,
+            "SpectroDataset": SpectroDataset,
+            "LTASDataset": LTASDataset,
+        }
+        if isinstance(analysis_dataset["dataset"], Path):
+            analysis_dataset_class = dataset_classes[analysis_dataset["class"]]
+            analysis_dataset["dataset"] = analysis_dataset_class.from_json(
+                analysis_dataset["dataset"],
+            )
+        return analysis_dataset["dataset"]
 
 
 DatasetChild = TypeVar("DatasetChild", bound=BaseDataset)

--- a/src/osekit/public_api/dataset.py
+++ b/src/osekit/public_api/dataset.py
@@ -834,6 +834,22 @@ class Dataset:
         self,
         analyis_dataset_name: str,
     ) -> type[DatasetChild]:
+        """Deserialize an analysis dataset from its json file.
+
+        The self.datasets property will be updated so that it stores the deserialized
+        dataset rather than the json file so that it is deserialized only once.
+
+        Parameters
+        ----------
+        analyis_dataset_name: str
+            Name of the analysis dataset.
+
+        Returns
+        -------
+        type[DatasetChild]:
+            The deserialized analysis dataset.
+
+        """
         analysis_dataset = self.datasets[analyis_dataset_name]
         dataset_classes = {
             "AudioDataset": AudioDataset,

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1615,3 +1615,91 @@ def test_build_specific_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
     assert np.array_equal(base_folder, [p3, p4])
     assert np.array_equal(dest_folder, [p1, p2])
     assert np.array_equal(built_files, [p1, p2])
+
+
+def test_deserialize_analysis_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
+    ds = Dataset(
+        folder=Path("grizzly"),
+        strptime_format="bear",
+    )
+
+    dummy_ads = AudioDataset([])
+    dummy_sds = SpectroDataset([])
+    dummy_ltasds = LTASDataset([])
+
+    ds.datasets |= {
+        "original": {
+            "class": "AudioDataset",
+            "analysis": "original",
+            "dataset": Path("original.json"),
+        },
+        "spectro": {
+            "class": "SpectroDataset",
+            "analysis": "spectro",
+            "dataset": Path("spectro.json"),
+        },
+        "ltas": {
+            "class": "LTASDataset",
+            "analysis": "ltas",
+            "dataset": Path("ltas.json"),
+        },
+    }
+
+    json_calls = [0]
+
+    def mock_from_json(
+        mock_instance: AudioDataset | SpectroDataset | LTASDataset,
+    ) -> AudioDataset | SpectroDataset | LTASDataset:
+        json_calls[0] += 1
+        return mock_instance
+
+    monkeypatch.setattr(AudioDataset, "from_json", lambda _: mock_from_json(dummy_ads))
+    monkeypatch.setattr(
+        SpectroDataset,
+        "from_json",
+        lambda _: mock_from_json(dummy_sds),
+    )
+    monkeypatch.setattr(
+        LTASDataset,
+        "from_json",
+        lambda _: mock_from_json(dummy_ltasds),
+    )
+
+    assert isinstance(ds.datasets["original"]["dataset"], Path)
+
+    # Getting the dataset should deserialize it
+    _ = ds.get_dataset("original")
+    assert json_calls[0] == 1
+
+    # The deserialized dataset should be stored
+    assert isinstance(ds.datasets["original"]["dataset"], AudioDataset)
+
+    # Getting the dataset again should use the cached dataset
+    _ = ds.get_dataset("original")
+    assert json_calls[0] == 1
+
+    assert isinstance(ds.datasets["spectro"]["dataset"], Path)
+
+    # Getting the dataset should deserialize it
+    _ = ds.get_dataset("spectro")
+    assert json_calls[0] == 2
+
+    # The deserialized dataset should be stored
+    assert isinstance(ds.datasets["spectro"]["dataset"], SpectroDataset)
+
+    # Getting the dataset again should use the cached dataset
+    _ = ds.get_dataset("spectro")
+    assert json_calls[0] == 2
+
+    assert isinstance(ds.datasets["ltas"]["dataset"], Path)
+
+    # Getting the dataset should deserialize it
+    _ = ds.get_dataset("ltas")
+    assert json_calls[0] == 3
+
+    # The deserialized dataset should be stored
+    assert isinstance(ds.datasets["ltas"]["dataset"], LTASDataset)
+
+    # Getting the dataset again should use the cached dataset
+    _ = ds.get_dataset("ltas")
+    assert json_calls[0] == 3

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -289,10 +289,7 @@ def test_dataset_build(
 
     # The dataset.json file in root folder should allow for deserializing the dataset
     dataset2 = Dataset.from_json(tmp_path / "dataset.json")
-    assert (
-        dataset2.datasets["original"]["dataset"]
-        == dataset.datasets["original"]["dataset"]
-    )
+    assert dataset2.origin_dataset == dataset.datasets["original"]["dataset"]
 
     # Resetting the dataset should put back all original files back
     dataset.reset()

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -584,6 +584,12 @@ def test_serialization(
 
     deserialized = Dataset.from_json(tmp_path / "dataset.json")
 
+    # analysis dataset deserialization is only done on request
+    assert all(
+        isinstance(analysis_dataset["dataset"], Path)
+        for analysis_dataset in deserialized.datasets.values()
+    )
+
     for (t_o, d_o), (t_d, d_d) in zip(
         sorted(dataset.datasets.items(), key=lambda d: d[0]),
         sorted(deserialized.datasets.items(), key=lambda d: d[0]),


### PR DESCRIPTION
# 🐳 WHATISHAPPENING

We're having some trouble when deserializing `osekit.public_api.dataset.Dataset` instances from `.json` files that are linked to a lot of audio files, because it implies fully deserializing all the analysis datasets and it can take quite some time (I have to open each file to read the metadata because the `AudioFile`s are deserialized too on dataset deserialization

# 🐳 HOWDOWEFIXIT

This is a first (naive) step: now, deserializing the public Dataset will only store the **path** of the analysis datasets jsons:

<img width="961" height="180" alt="image" src="https://github.com/user-attachments/assets/3d7fb22b-8266-4602-baf5-6f2cb0284164" />

Then, these analysis datasets will only be deserialized on request, e.g.: 

```py
sds = dataset.get_dataset("maxicoolyo") # Deserializes, stores and returns the SpectroDataset
```

<img width="664" height="262" alt="image" src="https://github.com/user-attachments/assets/50500081-110f-4401-8cb3-234b60d94f77" />
