### PR TITLE
fix old import name in job doc

### DIFF
--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -54,17 +54,20 @@ and follow the console arguments of the :mod:`osekit.public.export` script.
 .. code-block:: python
 
     import os
+    from pathlib import Path
 
-    from osekit.core.spectro_dataset import SpectroDataset
+    from pandas import Timedelta
+
     from osekit.core.audio_dataset import AudioDataset
-    from osekit.utils.job import JobConfig, Job
+    from osekit.core.spectro_dataset import SpectroDataset
+    from osekit.public import export_transform
 
     # Some Public API imports are required
     from osekit.public.transform import OutputType
-    from osekit.public import export
+    from osekit.utils.job import Job, JobConfig
 
-    ads = AudioDataset(...) # See the AudioDataset doc
-    sds = SpectroDataset(...) # See the SpectroDataset doc
+    ads = AudioDataset(...)  # See the AudioDataset doc
+    sds = SpectroDataset(...)  # See the SpectroDataset doc
 
     # We must specify the folder in which the files will be exported
     # This is an example with both audio and spectro exports.
@@ -72,28 +75,31 @@ and follow the console arguments of the :mod:`osekit.public.export` script.
     sds.folder = Path(...)
 
     # Datasets must be serialized
-    ads.write_json(ads.folder/"output")
-    sds.write_json(sds.folder/"output")
+    ads.write_json(ads.folder / "output")
+    sds.write_json(sds.folder / "output")
 
     # Export specifications
     # All parameters are listed in this example, but all parameters other than transform have default values
     args = {
-        "output_type": (OutputType.AUDIO|OutputType.SPECTROGRAM).value,
-        "ads-json": ads.foler/"output"/f"{ads.name}.json",
-        "sds-json": sds.foler/"output"/f"{sds.name}.json",
+        "output_type": (OutputType.AUDIO | OutputType.SPECTROGRAM).value,
+        "ads-json": ads.foler / "output" / f"{ads.name}.json",
+        "sds-json": sds.foler / "output" / f"{sds.name}.json",
         "subtype": "FLOAT",
-        "spectrum-folder-path": "None", # Folder in which npz matrices are exported
-        "spectrogram-folder-path": sds.folder/"output", # Folder in which png spectrograms are exported
+        "spectrum-folder-path": "None",  # Folder in which npz matrices are exported
+        "spectrogram-folder-path": sds.folder
+        / "output",  # Folder in which png spectrograms are exported
         "welch-folder-path": "None",  # Folder in which npz welch matrices are exported
-        "first": 0, # First data of the dataset to be exported
-        "last": len(ads.data), # Last data of the dataset to be exported, up to the last one if not included
+        "first": 0,  # First data of the dataset to be exported
+        "last": len(
+            ads.data,
+        ),  # Last data of the dataset to be exported, up to the last one if not included
         "downsampling-quality": "HQ",
         "upsampling-quality": "VHQ",
         "umask": 0o022,
-        "tqdm-disable": "False", # Disable TQDM progress bars
+        "tqdm-disable": "False",  # Disable TQDM progress bars
         "multiprocessing": "True",
         "nb-processes": "None",  # Should be a string. "None" uses the max number of processes, otherwise e.g. "3" will use 3.
-        "use-logging-setup": "True", # Call osekit.setup_logging() before exporting the dataset.
+        "use-logging-setup": "True",  # Call osekit.setup_logging() before exporting the dataset.
     }
 
     # Job and server configuration
@@ -103,15 +109,15 @@ and follow the console arguments of the :mod:`osekit.public.export` script.
         mem="60gb",
         walltime=Timedelta(hours=1),
         venv_name=os.environ["CONDA_DEFAULT_ENV"],
-        queue="omp"
+        queue="omp",
     )
 
     job = Job(
-        script_path = Path(export.__file__),
+        script_path=Path(export_transform.__file__),
         script_args=args,
         config=job_config,
         name="test_job_core",
-        output_folder=Path(...), # Path in which the .out and .err files are written
+        output_folder=Path(...),  # Path in which the .out and .err files are written
     )
 
     # Write the PBS file and submit the job


### PR DESCRIPTION
# 🥸

I had left an old `from osekit.public import export` (which has been renamed to `export_transform` in OSEkit 1.0) in the job doc, this PR should fix it!

<img width="513" height="487" alt="image" src="https://github.com/user-attachments/assets/e552ea32-cc8e-4820-9049-3d61bc961d81" />
