### PR TITLE
raise a ValueError when user tries to delete an unexisting transform

### DIFF
--- a/src/osekit/public/project.py
+++ b/src/osekit/public/project.py
@@ -744,6 +744,10 @@ class Project:
             Name of the transform whose output to delete.
 
         """
+        if transform_name not in self.transforms:
+            message = f"Transform '{transform_name}' not found."
+            raise ValueError(message)
+
         for dataset_to_delete in self.get_output_by_transform_name(
             transform_name,
         ):

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1397,6 +1397,10 @@ def test_delete_output(
         assert all(ds.name in proj.outputs.keys() for ds in datasets_to_keep)
         assert not any(ds.name in proj.outputs.keys() for ds in datasets_to_delete)
 
+    # Trying to delete an unexisting transform should raise:
+    with pytest.raises(ValueError, match="'FrankieCosmos'"):
+        project.delete_transform_with_outputs("FrankieCosmos")
+
 
 def test_existing_output_warning(
     tmp_path: pytest.fixture,


### PR DESCRIPTION
This PR adds a ValueError raising if `Project.delete_transform_with_outputs()` is called with an unexisting transform name:

```py
project.delete_transform_with_outputs("Maellezilla")

Traceback (most recent call last):
  File "C:\Users\berthoga\Documents\GitHub\OSEkit\.venv\Lib\site-packages\IPython\core\interactiveshell.py", line 3701, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<ipython-input-10-438fc50a0a98>", line 1, in <module>
    project.delete_transform_with_outputs("Maellezilla")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "C:\Users\berthoga\Documents\GitHub\OSEkit\src\osekit\public\project.py", line 749, in delete_transform_with_outputs
    raise ValueError(message)
ValueError: Transform 'Maellezilla' not found.
```

resolves #370 