### PR TITLE
replace missing acknowledgments link with documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 [Presentation](#presentation) •
 [Getting into it](#getting-into-it) •
-[Acknowledgements](#acknowledgements)
+[Documentation](https://project-osmose.github.io/OSEkit/)
 # ㅤ
 
 </div>


### PR DESCRIPTION
The readme had a dead link to an _acknowledgments_ section, I replaced it with a link to the documentation.

<img width="498" height="281" alt="QuinquinCarpentierGIF" src="https://github.com/user-attachments/assets/1e91a018-b856-4d75-8c99-1c240d3e42db" />
