### PR TITLE
instantaneous events

### DIFF
--- a/src/osekit/core/event.py
+++ b/src/osekit/core/event.py
@@ -37,7 +37,7 @@ class Event:
 
     @begin.setter
     def begin(self, value: Timestamp) -> None:
-        if hasattr(self, "_end") and value >= self._end:
+        if hasattr(self, "_end") and value > self._end:
             msg = f"Invalid Event: `end` ({self._end}) must be greater than `begin` ({value})."  # noqa: E501
             raise ValueError(msg)
         self._begin = value
@@ -49,7 +49,7 @@ class Event:
 
     @end.setter
     def end(self, value: Timestamp) -> None:
-        if hasattr(self, "_begin") and value <= self._begin:
+        if hasattr(self, "_begin") and value < self._begin:
             msg = f"Invalid Event: `end` ({value}) must be greater than `begin` ({self._begin})."  # noqa: E501
             raise ValueError(msg)
         self._end = value

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -85,7 +85,7 @@ from osekit.core.event import Event
         ),
         pytest.param(
             Event(
-                begin=Timestamp("2024-01-01 0:00:00"),
+                begin=Timestamp("2024-01-01 00:00:00"),
                 end=Timestamp("2024-01-01 12:00:00"),
             ),
             Event(
@@ -94,6 +94,18 @@ from osekit.core.event import Event
             ),
             False,
             id="border_sharing_isnt_overlapping",
+        ),
+        pytest.param(
+            Event(
+                begin=Timestamp("2024-01-01 00:00:00"),
+                end=Timestamp("2024-01-01 00:00:00"),
+            ),
+            Event(
+                begin=Timestamp("2024-01-01 00:00:00"),
+                end=Timestamp("2024-01-01 00:00:00"),
+            ),
+            False,
+            id="instantaneous_events_dont_overlap",
         ),
     ],
 )
@@ -390,7 +402,12 @@ def test_get_overlapping_events(
             ),
             Timestamp("2024-01-01 01:00:00"),
             None,
-            pytest.raises(ValueError, match="`end`.*must be greater than `begin`.*"),
+            nullcontext(
+                Event(
+                    begin=Timestamp("2024-01-01 01:00:00"),
+                    end=Timestamp("2024-01-01 01:00:00"),
+                ),
+            ),
             id="begin_equals_end",
         ),
     ],
@@ -423,11 +440,6 @@ def test_event_begin_end_updates(
             Timestamp("2024-01-02 00:00:00"),
             Timestamp("2024-01-01 00:00:00"),
             id="begin_after_end",
-        ),
-        pytest.param(
-            Timestamp("2024-01-01 00:00:00"),
-            Timestamp("2024-01-01 00:00:00"),
-            id="begin_equals_end",
         ),
     ],
 )

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import nullcontext
 
 import pytest
-from pandas import Timestamp
+from pandas import Timedelta, Timestamp
 
 from osekit.core.event import Event
 
@@ -458,3 +458,28 @@ def test_repr() -> None:
         )
         == "1990-09-12 12:00:00 - 1990-09-12 12:00:10"
     )
+
+
+@pytest.mark.parametrize(
+    ("event", "expected_duration"),
+    [
+        pytest.param(
+            Event(
+                begin=Timestamp("1990-09-12 12:00:00"),
+                end=Timestamp("1990-09-12 12:00:10"),
+            ),
+            Timedelta(seconds=10),
+            id="non-instantaneous_event",
+        ),
+        pytest.param(
+            Event(
+                begin=Timestamp("1990-09-12 12:00:10"),
+                end=Timestamp("1990-09-12 12:00:10"),
+            ),
+            Timedelta(seconds=0),
+            id="instantaneous_event",
+        ),
+    ],
+)
+def test_duration(event: Event, expected_duration: Timedelta) -> None:
+    assert event.duration == expected_duration


### PR DESCRIPTION
# 🐸 

The `Event` class didn't allow for cases where `begin == end`.

It raises an issue when trying to parse `Annotation` results as Events, since some annotations can be of type `POINT` and have a `0s`-duration.

This PR changes the begin/end constraint to `begin <= end`, according to the tests it doesn't break anything so 🤞

<img width="498" height="498" alt="ParksAndRecParksAndRecreationGIF" src="https://github.com/user-attachments/assets/f1f8518e-f2df-49d5-9230-1351734ec90f" />
 