### PR TITLE
Add dependabot version update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Paris"
+    groups:
+      dev-deps:
+        dependency-type: "development"
+      prod-deps:
+        dependency-type: "production"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Paris"
+    groups:
+      everything:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR adds version update configuration for dependabot: If I didn't mess anything up _amphigueye_, it should create 2 PRs each monday morning: one for updating the prod dependencies and one for the dev ones.

<img width="498" height="373" alt="TrailerParkBoysSpaceWeedEricGIF" src="https://github.com/user-attachments/assets/7d59e6a9-d666-45c5-9359-dfcaff579ec7" />
