### PR TITLE
group rest of dependency updates in a group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,8 @@ updates:
         dependency-type: "development"
       prod-deps:
         dependency-type: "production"
-      all-deps:
-        patterns:
-          "*"
+      indirect-deps:
+        dependency-type: "indirect"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
         dependency-type: "development"
       prod-deps:
         dependency-type: "production"
+      all-deps:
+        patterns:
+          "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,6 +30,6 @@ updates:
       time: "08:00"
       timezone: "Europe/Paris"
     groups:
-      everything:
+      gh-actions:
         patterns:
           - "*"


### PR DESCRIPTION
If I'm not mistaken, this should group all version bumps of indirect packages in a same PR

