### PR TITLE
Dependabot config bis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,21 @@ updates:
         dependency-type: "development"
       prod-deps:
         dependency-type: "production"
+
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Paris"
+    allow:
+      dependency-type: "indirect"
+    groups:
       indirect-deps:
-        dependency-type: "indirect"
+        patterns: "*"
+
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,8 @@ updates:
         dependency-type: "development"
       prod-deps:
         dependency-type: "production"
-      all-deps:
-        patterns:
-          "*"
+      indirect-deps:
+        dependency-type: "indirect"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
         dependency-type: "development"
       prod-deps:
         dependency-type: "production"
+      all-deps:
+        patterns:
+          "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,6 +30,6 @@ updates:
       time: "08:00"
       timezone: "Europe/Paris"
     groups:
-      everything:
+      gh-actions:
         patterns:
           - "*"


### PR DESCRIPTION
Ok so APPARENTLY the [dependency-type parameter in groups](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference?search-overlay-input=dependency-type#groups--) takes less values than [dependency-type parameter in allow](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference?search-overlay-input=dependency-type#dependency-type-allow).

This might work 

<img width="498" height="357" alt="TheOfficeGIF" src="https://github.com/user-attachments/assets/99089f91-e2f4-4700-aeb8-e08f3fde8051" />
