### PR TITLE
Remove 'uv' package ecosystem configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,18 +18,6 @@ updates:
         dependency-type: "development"
       prod-deps:
         dependency-type: "production"
-
-
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-      timezone: "Europe/Paris"
-    allow:
-      dependency-type: "indirect"
-    groups:
       indirect-deps:
         patterns:
           - "*"


### PR DESCRIPTION
Removed configuration for the 'uv' package ecosystem from Dependabot.

Add indirect-deps as a token pattern