### PR TITLE
Ensure paths

### DIFF
--- a/src/osekit/public/project.py
+++ b/src/osekit/public/project.py
@@ -29,7 +29,7 @@ from osekit.utils.core import (
     file_indexes_per_batch,
     get_umask,
 )
-from osekit.utils.path import move_tree
+from osekit.utils.path import move_tree, ensure_within_base
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -234,6 +234,7 @@ class Project:
             return
 
         logs_directory = self.folder / self.SUBFOLDERS["log"]
+        ensure_within_base(path=logs_directory, base=self.folder)
         if not logs_directory.exists():
             logs_directory.mkdir(mode=DPDEFAULT, parents=True)
         self.logger = logging.getLogger("project").getChild(self.folder.name)

--- a/src/osekit/utils/path.py
+++ b/src/osekit/utils/path.py
@@ -52,3 +52,52 @@ def is_absolute(path: PathLike | str) -> bool:
         if formatted_path.is_absolute():
             return True
     return False
+
+
+def ensure_within_base(path: Path, base: Path) -> Path:
+    """Ensure that a path resolves to a location contained within a base folder.
+
+    This guards against path traversal / path injection: if ``path`` is built
+    (even partly) from untrusted data (e.g. a value read from a JSON project
+    file, or from another user's dataset), a crafted value such as
+    ``../../../home/other_user/.ssh`` could otherwise make OSEkit read,
+    write, move or delete files outside the folder it is supposed to
+    operate in.
+
+    Parameters
+    ----------
+    path: Path
+        The path to validate. Doesn't need to exist yet (this also covers
+        paths that are about to be created, e.g. before a ``mkdir()``).
+    base: Path
+        The folder that ``path`` is expected to stay within.
+        This is typically the ``Project`` root folder, i.e. the boundary of
+        what the running process is allowed to touch.
+
+    Returns
+    -------
+    Path:
+        The resolved (absolute, symlink-free) version of ``path``.
+
+    Raises
+    ------
+    ValueError:
+        If the resolved ``path`` is not ``base`` itself and not located
+        inside ``base``.
+
+    Examples
+    --------
+    >>> ensure_within_base(Path("/data/project/log"), Path("/data/project"))
+    PosixPath('/data/project/log')
+    >>> ensure_within_base(Path("/data/project/../../etc"), Path("/data/project"))
+    Traceback (most recent call last):
+        ...
+    ValueError: Path '/data/project/../../etc' escapes the allowed directory '/data/project'.
+
+    """  # noqa: E501
+    resolved_path = path.resolve()
+    resolved_base = base.resolve()
+    if resolved_path != resolved_base and resolved_base not in resolved_path.parents:
+        msg = f"Path '{path}' escapes the allowed directory '{base}'."
+        raise ValueError(msg)
+    return resolved_path

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from contextlib import nullcontext
+from contextlib import nullcontext, AbstractContextManager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -21,7 +21,7 @@ from osekit.utils.core import (
     nb_files_per_batch,
 )
 from osekit.utils.deserialization import deserialize_spectro_or_ltas_dataset
-from osekit.utils.path import is_absolute, move_tree
+from osekit.utils.path import is_absolute, move_tree, ensure_within_base
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -133,6 +133,36 @@ def test_move_tree(
 )
 def test_is_absolute(path: str, expected: bool) -> None:
     assert is_absolute(path) == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "base", "expected"),
+    [
+        pytest.param(
+            Path("built/to/spill"),
+            Path(r"built"),
+            nullcontext(Path("built/to/spill").resolve()),
+            id="subfolder_of_base_is_ok",
+        ),
+        pytest.param(
+            Path("built/to/spill"),
+            Path(r"built/to/spill"),
+            nullcontext(Path("built/to/spill").resolve()),
+            id="same_folder_than_base_is_ok",
+        ),
+        pytest.param(
+            Path("built/to/spill"),
+            Path(r"daniel/johnston"),
+            pytest.raises(ValueError, match="escapes the allowed directory"),
+            id="not_in_base_should_raise",
+        ),
+    ],
+)
+def test_ensure_within_base(
+    path: Path, base: Path, expected: AbstractContextManager
+) -> None:
+    with expected as e:
+        assert ensure_within_base(path=path, base=base) == e
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes the security issue SonarQube raised [here](https://github.com/Gautzilla/OSEkit/runs/89916629843)

Basically, it just checks that the `log` folder created in the Public API is a child of the `Project` folder to avoid calling `mkdir()` anywhere.

