### PR TITLE
fix bullet list in installation warning doc page

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -81,5 +81,6 @@ Follow the same instructions as in the :ref:`From Git <from-git>` section above,
 
     Installing ObsPy on Windows might be a stairway to hell.
     If installation fails, we recommend either:
+
     * Using Linux or `WSL <https://learn.microsoft.com/en-us/windows/wsl/install/>`_
     * Converting MiniSEED files to WAV/FLAC prior to processing


### PR DESCRIPTION
The bullet list in the installation page of the doc was messed up:

|before|after|
|:---:|:---:|
|<img width="788" height="109" alt="image" src="https://github.com/user-attachments/assets/13169adb-bd61-490e-9de1-fdf48877d967" />|<img width="792" height="156" alt="image" src="https://github.com/user-attachments/assets/16321f52-7931-43cf-903c-705df50b3890" />|